### PR TITLE
Allow dynamic board settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,40 +6,55 @@ import GridManager from "./gird.js";
 const canvas = document.querySelector('canvas')
 const ctx = canvas.getContext('2d')
 const restartButton = document.getElementById('restartButton');
+const widthInput = document.getElementById('gridWidth');
+const heightInput = document.getElementById('gridHeight');
+const winInput = document.getElementById('winCount');
 
 
 let globals = new Globals();
 let game = new Game();
-let gridManager = new GridManager();
+let gridManager;
 
+function applySettings(){
+    globals.rows = parseInt(widthInput.value) || globals.rows;
+    globals.columns = parseInt(heightInput.value) || globals.columns;
+    globals.winnerStackCount = parseInt(winInput.value) || globals.winnerStackCount;
+}
 
-game.maxMoveCount = gridManager.row  * gridManager.colm;
-    
-let canvasSize = Math.min(window.innerWidth / 1.5,window.innerHeight /1.5)
+let canvasSize;
 
-canvas.width = canvasSize;
-canvas.height = canvasSize;
+function updateCanvas(){
+    canvasSize = Math.min(window.innerWidth / 1.5,window.innerHeight /1.5)
+    canvas.width = canvasSize;
+    canvas.height = canvasSize;
+    globals.cellSize = canvasSize / globals.rows
+}
 
-globals.cellSize = canvasSize / globals.rows
+function createGrid(){
+    gridManager = new GridManager();
+    gridManager.initGrid();
+    game.maxMoveCount = gridManager.row  * gridManager.colm;
+}
 
+applySettings();
+updateCanvas();
+createGrid();
 
 document.getElementById("body").style.backgroundColor = globals.colors.bodyBg;
 canvas.style.backgroundColor = globals.colors.canvasBg;
-// canvas.style.border = `15px solid ${globals.colors.gridBorder}`; 
+// canvas.style.border = `15px solid ${globals.colors.gridBorder}`;
 
-gridManager.initGrid();
 game.displayScore();
 
-
 restartButton.addEventListener('click' ,  ()=>{
+    applySettings();
+    updateCanvas();
+    createGrid();
     game.restart(gridManager);
 })
 
 window.addEventListener('resize', ()=>{
-    canvasSize  = Math.min(window.innerWidth / 1.5,window.innerHeight /1.5)
-    canvas.width = canvasSize;
-    canvas.height = canvasSize;
-    globals.cellSize = canvasSize / globals.rows
+    updateCanvas();
     gridManager.resizeGrid();
 
 })

--- a/index.html
+++ b/index.html
@@ -61,6 +61,11 @@
     </style>
 </head>
 <body id="body">
+    <div class="settings">
+        <input id="gridWidth" type="number" value="3" min="1" />
+        <input id="gridHeight" type="number" value="3" min="1" />
+        <input id="winCount" type="number" value="3" min="1" />
+    </div>
     <canvas id="myCanvas"></canvas>
     <div class="container">
         <div class="box" id="leftBox">X</div>


### PR DESCRIPTION
## Summary
- add input fields to set grid width/height and win count
- read values on start and restart
- rebuild game board with new sizes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845b3c7f9ac8329b71ecd439467d404